### PR TITLE
Adding file existence checks

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1055,10 +1055,18 @@ confNetwork() {
     echo "$INPUT_CHAIN_EDITED" > /tmp/INPUT_CHAIN_EDITED
     echo "$FORWARD_CHAIN_EDITED" > /tmp/FORWARD_CHAIN_EDITED
 
-    $SUDO cp /tmp/noUFW /etc/pivpn/NO_UFW
-    $SUDO cp /tmp/OLD_UFW /etc/pivpn/OLD_UFW
-    $SUDO cp /tmp/INPUT_CHAIN_EDITED /etc/pivpn/INPUT_CHAIN_EDITED
-    $SUDO cp /tmp/FORWARD_CHAIN_EDITED /etc/pivpn/FORWARD_CHAIN_EDITED
+    if [ -f "/tmp/noUFW" ]; then
+        $SUDO cp /tmp/noUFW /etc/pivpn/NO_UFW
+    fi
+    if [ -f "/tmp/OLD_UFW" ]; then
+        $SUDO cp /tmp/OLD_UFW /etc/pivpn/OLD_UFW
+    fi
+    if [ -f "/tmp/INPUT_CHAIN_EDITED" ]; then
+        $SUDO cp /tmp/INPUT_CHAIN_EDITED /etc/pivpn/INPUT_CHAIN_EDITED
+    fi
+    if [ -f "/tmp/FORWARD_CHAIN_EDITED" ]; then
+        $SUDO cp /tmp/FORWARD_CHAIN_EDITED /etc/pivpn/FORWARD_CHAIN_EDITED
+    fi
 }
 
 confOVPN() {


### PR DESCRIPTION
The script has copy commands for files that may not exist. This left a bug which would cause the unattended installer to exit prematurely. Added file existence checks to these copy commands to address this issue.

Addresses issue: https://github.com/pivpn/pivpn/issues/902